### PR TITLE
Cross-platform compatibility and project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+env/
+ENV/
+.env/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Application specific
+# Settings directory is now in user's home directory
+# ~/Library/Application Support/Astrocalibrator on macOS
+# %APPDATA%/Astrocalibrator on Windows
+# ~/.config/Astrocalibrator on Linux
+
+# Temporary files
+*.tmp
+*.log
+temp/
+tmp/
+
+# Nix
+.direnv/
+result
+result-*
+
+# Calibration output files
+calibrated_*
+*.fits
+*.fit
+*.fts
+# Uncomment if you want to ignore all image files
+# *.jpg
+# *.jpeg
+# *.png
+# *.tif
+# *.tiff

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746055187,
+        "narHash": "sha256-3dqArYSMP9hM7Qpy5YWhnSjiqniSaT2uc5h2Po7tmg0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e362ce63e16b9572d8c2297c04f7c19ab6725a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "Astrocalibrator - A lightweight calibration tool for astrophotography workflows";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        
+        pythonEnv = pkgs.python311.withPackages (ps: with ps; [
+          # Core dependencies
+          pillow
+          astropy
+          astroquery
+          scipy
+          numpy
+          
+          # Tkinter is required for the GUI
+          tkinter
+          
+          # Development tools
+          ipython
+          black
+          pylint
+        ]);
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pythonEnv
+            pkgs.git
+          ];
+          
+          shellHook = ''
+            echo "Welcome to Astrocalibrator development environment!"
+            echo "Python version: $(python --version)"
+            echo ""
+            echo "To run the application:"
+            echo "  python main.py"
+            echo ""
+            echo "Note: You'll need to install ASTAP separately for plate solving:"
+            echo "  Download from: https://www.hnsky.org/astap.htm"
+            echo "  Configure the ASTAP executable location in the app settings"
+          '';
+          
+          # Set environment variables if needed
+          PYTHONPATH = "./";
+        };
+      }
+    );
+}

--- a/gui.py
+++ b/gui.py
@@ -629,6 +629,14 @@ def pop_log_out_to_window():
     log_textbox.see('end')
 
     log_embedded = False
+    
+    # Bring both windows to the foreground
+    root.lift()  # Bring main window to the foreground
+    root.focus_force()  # Force focus on main window
+    
+    # Bring log window to the foreground after a short delay
+    # This ensures both windows are visible to the user
+    root.after(100, lambda: external_log_window.lift())
 
 
 def browse_file(var):

--- a/gui.py
+++ b/gui.py
@@ -7,9 +7,26 @@ from PIL import Image, ImageTk
 import io
 import json
 
-# Settings management: safe AppData location
-SETTINGS_FILE = os.path.join(os.getenv('APPDATA'), 'Astrocalibrator', 'settings.json')
-os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
+# Settings management: cross-platform safe location
+def get_app_data_dir():
+    # Windows: use APPDATA
+    if os.name == 'nt' and os.getenv('APPDATA'):
+        return os.path.join(os.getenv('APPDATA'), 'Astrocalibrator')
+    # macOS: use ~/Library/Application Support
+    elif sys.platform == 'darwin':
+        return os.path.join(os.path.expanduser('~'), 'Library', 'Application Support', 'Astrocalibrator')
+    # Linux/Unix: use XDG_CONFIG_HOME or ~/.config
+    else:
+        config_home = os.getenv('XDG_CONFIG_HOME') or os.path.join(os.path.expanduser('~'), '.config')
+        return os.path.join(config_home, 'Astrocalibrator')
+
+# Ensure we have sys module imported
+import sys
+
+# Create settings directory and file path
+SETTINGS_DIR = get_app_data_dir()
+SETTINGS_FILE = os.path.join(SETTINGS_DIR, 'settings.json')
+os.makedirs(SETTINGS_DIR, exist_ok=True)
 
 def load_settings():
     try:

--- a/settings.py
+++ b/settings.py
@@ -1,9 +1,24 @@
 import os
+import sys
 import json
 
-# Define full settings path inside AppData
-SETTINGS_FILE = os.path.join(os.getenv('APPDATA'), 'Astrocalibrator', 'settings.json')
-os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
+# Cross-platform settings directory function
+def get_app_data_dir():
+    # Windows: use APPDATA
+    if os.name == 'nt' and os.getenv('APPDATA'):
+        return os.path.join(os.getenv('APPDATA'), 'Astrocalibrator')
+    # macOS: use ~/Library/Application Support
+    elif sys.platform == 'darwin':
+        return os.path.join(os.path.expanduser('~'), 'Library', 'Application Support', 'Astrocalibrator')
+    # Linux/Unix: use XDG_CONFIG_HOME or ~/.config
+    else:
+        config_home = os.getenv('XDG_CONFIG_HOME') or os.path.join(os.path.expanduser('~'), '.config')
+        return os.path.join(config_home, 'Astrocalibrator')
+
+# Create settings directory and file path
+SETTINGS_DIR = get_app_data_dir()
+SETTINGS_FILE = os.path.join(SETTINGS_DIR, 'settings.json')
+os.makedirs(SETTINGS_DIR, exist_ok=True)
 
 def load_settings():
     try:


### PR DESCRIPTION
- Added cross-platform settings storage:
  * macOS: ~/Library/Application Support/Astrocalibrator
  * Windows: %APPDATA%/Astrocalibrator
  * Linux: ~/.config/Astrocalibrator
- Fixed NoneType error when accessing APPDATA on non-Windows systems
- Added comprehensive .gitignore file for Python/Nix projects
- Added Nix flake for reproducible development environment
- Improved error handling for settings management